### PR TITLE
Bugfix - Clean Ruby

### DIFF
--- a/fluentd/plugins/filter_reverse_key.rb
+++ b/fluentd/plugins/filter_reverse_key.rb
@@ -10,11 +10,10 @@ module Fluent::Plugin
     def filter(tag, time, record)
       begin
         record[@key] = record[@key].reverse
+        return record
       rescue
         log.error('failed to reverse %s at %s' % [@key, record])
         return nil
-      else
-        return record
       end
     end
   end


### PR DESCRIPTION
- Remove redundant else in begin-rescue block 🧹 